### PR TITLE
Add a sed hack to update the shebang for Python scripts

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,9 @@ _bin_programs=(
 _BINDIR="${PREFIX}/bin"
 mkdir -p ${_BINDIR}
 for _prog in ${_bin_programs[@]}; do
+	# fix the sheband for Python
+	sed -i.tmp 's|#!/usr/bin/env python|#!/opt/anaconda1anaconda2anaconda3/bin/python|' "${_prog}"
+	# install the script
 	install -v -m 0755 "${_prog}" "${_BINDIR}/"
 done
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ source:
   sha256: 92b1c7d76dd8b103b24f7cec564c62fca9f4f2b01a5513dd8746eab6b0db06f3
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - sed  # [unix]
   host:
     - python
   run:


### PR DESCRIPTION
This PR adds a call to `sed` to replace the `/usr/bin/env python` shebang in Python scripts with the anaconda prompt prefix. This is automatically replaced at _install_ time with the prefix of the actual environment.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
